### PR TITLE
chore: bump sass-embedded from 1.87.0 to 1.89.1 in the other-dependencies group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "pagefind": "^1.3.0",
-        "sass-embedded": "^1.87.0"
+        "sass-embedded": "^1.89.1"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -5563,9 +5563,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.87.0.tgz",
-      "integrity": "sha512-1IA3iTJNh4BkkA/nidKiVwbmkxr9o6LsPegycHMX/JYs255zpocN5GdLF1+onohQCJxbs5ldr8osKV7qNaNBjg==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.89.1.tgz",
+      "integrity": "sha512-alvGGlyYdkSXYKOfS/TTxUD0993EYOe3adIPtwCWEg037qe183p2dkYnbaRsCLJFKt+QoyRzhsrbCsK7sbR6MA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5585,32 +5585,28 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.87.0",
-        "sass-embedded-android-arm64": "1.87.0",
-        "sass-embedded-android-ia32": "1.87.0",
-        "sass-embedded-android-riscv64": "1.87.0",
-        "sass-embedded-android-x64": "1.87.0",
-        "sass-embedded-darwin-arm64": "1.87.0",
-        "sass-embedded-darwin-x64": "1.87.0",
-        "sass-embedded-linux-arm": "1.87.0",
-        "sass-embedded-linux-arm64": "1.87.0",
-        "sass-embedded-linux-ia32": "1.87.0",
-        "sass-embedded-linux-musl-arm": "1.87.0",
-        "sass-embedded-linux-musl-arm64": "1.87.0",
-        "sass-embedded-linux-musl-ia32": "1.87.0",
-        "sass-embedded-linux-musl-riscv64": "1.87.0",
-        "sass-embedded-linux-musl-x64": "1.87.0",
-        "sass-embedded-linux-riscv64": "1.87.0",
-        "sass-embedded-linux-x64": "1.87.0",
-        "sass-embedded-win32-arm64": "1.87.0",
-        "sass-embedded-win32-ia32": "1.87.0",
-        "sass-embedded-win32-x64": "1.87.0"
+        "sass-embedded-android-arm": "1.89.1",
+        "sass-embedded-android-arm64": "1.89.1",
+        "sass-embedded-android-riscv64": "1.89.1",
+        "sass-embedded-android-x64": "1.89.1",
+        "sass-embedded-darwin-arm64": "1.89.1",
+        "sass-embedded-darwin-x64": "1.89.1",
+        "sass-embedded-linux-arm": "1.89.1",
+        "sass-embedded-linux-arm64": "1.89.1",
+        "sass-embedded-linux-musl-arm": "1.89.1",
+        "sass-embedded-linux-musl-arm64": "1.89.1",
+        "sass-embedded-linux-musl-riscv64": "1.89.1",
+        "sass-embedded-linux-musl-x64": "1.89.1",
+        "sass-embedded-linux-riscv64": "1.89.1",
+        "sass-embedded-linux-x64": "1.89.1",
+        "sass-embedded-win32-arm64": "1.89.1",
+        "sass-embedded-win32-x64": "1.89.1"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.87.0.tgz",
-      "integrity": "sha512-Z20u/Y1kFDpMbgiloR5YPLxNuMVeKQRC8e/n68oAAxf3u7rDSmNn2msi7USqgT1f2zdBBNawn/ifbFEla6JiHw==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.89.1.tgz",
+      "integrity": "sha512-wVchZSz8zbJBwwOs9/iwco/M5G3L5BaeqwUF1EC3Gtzn1BsXYUEkJfftW2HxGl4hQz2YlpR7BY1GRN817uxADA==",
       "cpu": [
         "arm"
       ],
@@ -5625,9 +5621,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.87.0.tgz",
-      "integrity": "sha512-uqeZoBuXm3W2KhxolScAAfWOLHL21e50g7AxlLmG0he7WZsWw6e9kSnmq301iLIFp4kvmXYXbXbNKAeu9ItRYA==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.89.1.tgz",
+      "integrity": "sha512-Je6x7uuJRGQdr5ziSJdaPA4NhBSO26BU/E55qiuMUZpjq2EWBEJPbNeugu/cWlCEmfqoVuxj37r8aEU+KG0H1g==",
       "cpu": [
         "arm64"
       ],
@@ -5641,27 +5637,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-android-ia32": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.87.0.tgz",
-      "integrity": "sha512-hSWTqo2Igdig528cUb1W1+emw9d1J4+nqOoR4tERS04zcwRRFNDiuBT0o5meV7nkEwE982F+h57YdcRXj8gTtg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.87.0.tgz",
-      "integrity": "sha512-kBAPSjiTBLy5ua/0LRNAJwOAARhzFU7gP35fYORJcdBuz1lkIVPVnid1lh9qQ6Ce9MOJcr7VKFtGnTuqVeig5A==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.89.1.tgz",
+      "integrity": "sha512-DhWe+A4RVtpHMVaQgdzRpiczAXKPl7XhyY9USkY9Xkhv94+csTfjyuFmsUuCpKSiQDQkD+rGByfg+9yQIk/RgQ==",
       "cpu": [
         "riscv64"
       ],
@@ -5676,9 +5655,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.87.0.tgz",
-      "integrity": "sha512-ZHMrNdtdMSpJUYco2MesnlPwDTZftD3pqkkOMI2pbqarPoFUKJtP5k80nwCM0sJGtqfNE+O16w9yPght0CMiJg==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.89.1.tgz",
+      "integrity": "sha512-LTEzxTXrv3evPiHBmDMtJtO5tEprg7bvNOwYTjDEhE9ZCYdb70l+haIY0dVyhGxyeaBJlyvatjWOKEduPP3Lyw==",
       "cpu": [
         "x64"
       ],
@@ -5693,9 +5672,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.87.0.tgz",
-      "integrity": "sha512-7TK1JWJdCIRSdZv5CJv/HpDz/wIfwUy2FoPz9sVOEj1pDTH0N+VfJd5VutCddIdoQN9jr0ap8vwkc65FbAxV2A==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.89.1.tgz",
+      "integrity": "sha512-7qMO4BLdIOFMMc1M+hg5iWEjPxbPlH1XTPUCwyuXYqubz6kXkdrrtJXolNAAey/0ZOE6uXk0APugm93a/veQdQ==",
       "cpu": [
         "arm64"
       ],
@@ -5710,9 +5689,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.87.0.tgz",
-      "integrity": "sha512-2JiQzt7FmgUC4MYT2QvbeH/Bi3e76WEhaYoc5P3WyTW8unsHksyTdMuTuYe0Qf9usIyt6bmm5no/4BBw7c8Cig==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.89.1.tgz",
+      "integrity": "sha512-Jzuws3NNx4YtDdL2/skP8BvGqMBKn26XINehwLnD2kgbh0+k+vKNWt5JDomvIuZVLsK8zWrMoRkXpk4wuHdqrw==",
       "cpu": [
         "x64"
       ],
@@ -5727,9 +5706,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.87.0.tgz",
-      "integrity": "sha512-z5P6INMsGXiUcq1sRRbksyQUhalFFYjTEexuxfSYdK3U2YQMADHubQh8pGzkWvFRPOpnh83RiGuwvpaARYHnsw==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.89.1.tgz",
+      "integrity": "sha512-8TvFr/lh7FARtNr9mM57m7NNvtSZwnlkXtfY1D48B81Ve6GgtLqQhELNzvTcfQ0WZa0aNnVjq9XUuWLlrMDaZQ==",
       "cpu": [
         "arm"
       ],
@@ -5744,9 +5723,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.87.0.tgz",
-      "integrity": "sha512-5z+mwJCbGZcg+q+MwdEVSh0ogFK7OSAe175Gsozzr/Izw34Q+RGUw9O82jsV2c4YNuTAQvzEHgIO5cvNvt3Quw==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.89.1.tgz",
+      "integrity": "sha512-h967EV2armjV+Re+hHv7LaIzCOvV6DoFod9GJhXTdnPvilqs7DAPTUfN07wOqbzjlaGEnITZXzLsWAoZ1Z7tWQ==",
       "cpu": [
         "arm64"
       ],
@@ -5760,27 +5739,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.87.0.tgz",
-      "integrity": "sha512-Xzcp+YPp0iakGL148Jl57CO+MxLuj2jsry3M+rc1cSnDlvkjNVs6TMxaL70GFeV5HdU2V60voYcgE7adDUtJjw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.87.0.tgz",
-      "integrity": "sha512-4PyqOWhRzyu06RRmpCCBOJdF4BOv7s446wrV6yODtEyyfSIDx3MJabo3KT0oJ1lTWSI/aU3R89bKx0JFXcIHHw==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.89.1.tgz",
+      "integrity": "sha512-Tl8wDL+3qFa/AhvZZBb1OvhN1SvIsRSLaPdGP8cv3VmKKVBdlLp2zedPTlcLJpR9dG/bjtGJYGX15kWHAvZ6mQ==",
       "cpu": [
         "arm"
       ],
@@ -5795,9 +5757,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.87.0.tgz",
-      "integrity": "sha512-HWE5eTRCoKzFZWsxOjDMTF5m4DDTQ0n7NJxSYiUXPBDydr9viPXbGOMYG7WVJLjiF7upr7DYo/mfp/SNTMlZyg==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.89.1.tgz",
+      "integrity": "sha512-l4TrsUmE3AEPy2gDThb+OQV5xSyrb807DJbkQiFtTwvtOZAAkoVl1v2QeocW0npgKjc/W7nHMiSempJe0UcV7w==",
       "cpu": [
         "arm64"
       ],
@@ -5811,27 +5773,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.87.0.tgz",
-      "integrity": "sha512-aQaPvlRn3kh93PLQvl6BcFKu8Ji92+42blFEkg6nMVvmugD5ZwH2TGFrX25ibx4CYxRpMS4ssF7a0i7vy5HB1Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.87.0.tgz",
-      "integrity": "sha512-o5DxcqiFzET3KRWo+futHr/lhAMBP3tJGGx8YIgpHQYfvDMbsvE0hiFC+nZ/GF9dbcGd+ceIQwfvE5mcc7Gsjw==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.89.1.tgz",
+      "integrity": "sha512-YJVZmz032U7dv4RW3u+SJGp+DQWmYWc5fX/aXzLuoL6PPUPon1/Sseaf/5YGtcuQf8RnxZBbM2nFHFVHDJfsQw==",
       "cpu": [
         "riscv64"
       ],
@@ -5846,9 +5791,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.87.0.tgz",
-      "integrity": "sha512-dKxWsu9Wu/CyfzQmHdeiGqrRSzJ85VUjbSx+aP1/7ttmps3SSg+YW95PuqnCOa7GSuSreC3dKKpXHTywUxMLQA==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.89.1.tgz",
+      "integrity": "sha512-67ijpk87V0VlpdVTtgnfIzRkVUMtEH79nvGctvNpk0XT6v+oxoFRljFRiYItZOxb5gRZMnvtkgaz1VHVcMrhtg==",
       "cpu": [
         "x64"
       ],
@@ -5863,9 +5808,9 @@
       }
     },
     "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.87.0.tgz",
-      "integrity": "sha512-Sy3ESZ4FwBiijvmTA9n+0p0w3MNCue1AgINVPzpAY27EFi0h49eqQm9SWfOkFqmkFS2zFRYowdQOr5Bbr2gOXA==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.89.1.tgz",
+      "integrity": "sha512-SQNWy5kUvlQJUKRXFy8jS05DBik+2ERIWDxOBk+QuJYEIktlA9fKKBU8c7RkgpZFNXSXZa0W1Gy27oOFCzhhuA==",
       "cpu": [
         "riscv64"
       ],
@@ -5880,9 +5825,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.87.0.tgz",
-      "integrity": "sha512-+UfjakOcHHKTnEqB3EZ+KqzezQOe1emvy4Rs+eQhLyfekpYuNze/qlRvYxfKTmrtvDiUrIto8MXsyZfMLzkuMA==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.89.1.tgz",
+      "integrity": "sha512-KUqGzBvTDZG6D3Pq41sCzqO1wkxM0WmxxlI7PTuVkvgciTywHf8F7mkg2alMLVZQ6APJEYtlnCGQgn4cCgYsqw==",
       "cpu": [
         "x64"
       ],
@@ -5897,9 +5842,9 @@
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.87.0.tgz",
-      "integrity": "sha512-m1DS6FYUE0/fv+vt38uQB/kxR4UjnyD+2zcSc298pFmA0aYh/XZIPWw7RxG1HL3KLE1ZrGyu3254MPoxRhs3ig==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.89.1.tgz",
+      "integrity": "sha512-Lk6dYA18RasZxQhShT91G7Z2o7+F9necTNJ951a5AICsSJpTbg3tTnAGB7Rvd6xB5reQSZoXfB/zXKEKwtzaow==",
       "cpu": [
         "arm64"
       ],
@@ -5913,27 +5858,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.87.0.tgz",
-      "integrity": "sha512-JztXLo59GMe2E6g+kCsyiERYhtZgkcyDYx6CrXoSTE5WaE+RbxRiCCCv8/1+hf406f08pUxJ8G0Ody7M5urtBA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.87.0.tgz",
-      "integrity": "sha512-4nQErpauvhgSo+7ClumGdjdf9sGx+U9yBgvhI0+zUw+D5YvraVgvA0Lk8Wuwntx2PqnvKUk8YDr/vxHJostv4Q==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.89.1.tgz",
+      "integrity": "sha512-YlvzrzFPHd4GKa04jMfP0t2DGJHPTm7zN4GEYtaOFqeS6BoEAUY5kBNYFy7zhwKesN3kGyU/D9rz1MfLRgGv0g==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmmirror.com/@bufbuild/protobuf/-/protobuf-2.2.0.tgz",
-      "integrity": "sha512-+imAQkHf7U/Rwvu0wk1XWgsP3WnpCWmK7B48f0XqSNzgk64+grljTKC7pnO/xBiEMUziF7vKRfbBnOQhg126qQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.1.tgz",
+      "integrity": "sha512-lut4UTvKL8tqtend0UDu7R79/n9jA7Jtxf77RNPbxtmWqfWI4qQ9bTjf7KCS4vfqLmpQbuHr1ciqJumAgJODdw==",
       "devOptional": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "pagefind": "^1.3.0",
-    "sass-embedded": "^1.87.0"
+    "sass-embedded": "^1.89.1"
   }
 }


### PR DESCRIPTION
do #22 manually, update `@bufbuild/protobuf` additionally to fix build error